### PR TITLE
Generate config file veth_mac_addrs.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Build the relevant xdp-progs, applications and container image by running
 
 ### Setting up the containers
 
-Setup the containers by running the `source ./container_setup.sh` script. This will
+Setup the containers by running the `./container_setup.sh` script. This will
 create the following setup:
 
 ```bash
@@ -77,6 +77,9 @@ create the following setup:
 #       +---------------------------------------------------------+
 ```
 
+The veth MAC addresses are extracted stored in `veth_mac_addrs.conf`
+which gets used by script `veth_setup.sh`.
+
 ### Setting xdp progs on the host side veths
 
 Run the `veth_setup.sh` script to:
@@ -84,7 +87,7 @@ Run the `veth_setup.sh` script to:
 - Install the xdp-redirection program on veth1 and veth5.
 - Install the xdp-pass program on veth7 and veth3.
 
-> **_NOTE:_** Modify the MAC addresses in the script as appropriate.
+> **_NOTE:_** Modify the MAC addresses in script/`veth_mac_addrs.conf as appropriate.
 
 ```cmd
 # ./veth_setup.sh -n

--- a/container_setup.sh
+++ b/container_setup.sh
@@ -144,6 +144,11 @@ docker exec -ti cndp-2 arp -s 192.168.100.20 $mac_veth4
 echo "veth8 192.168.200.40 mac_address = $mac_veth8"
 echo "veth4 192.168.100.20 mac_address = $mac_veth4"
 
+FILE=veth_mac_addrs.conf
+
+echo "Created file: $FILE with MAC-addrs"
+cat <<EOF > $FILE
+# Config MAC addrs used in script veth_setup.sh
 export mac_veth1=$mac_veth4
 export mac_veth2=$mac_veth2
 export mac_veth3=$mac_veth3
@@ -152,3 +157,4 @@ export mac_veth5=$mac_veth5
 export mac_veth6=$mac_veth6
 export mac_veth7=$mac_veth7
 export mac_veth8=$mac_veth8
+EOF


### PR DESCRIPTION
Instead of sourcing container_setup.sh, generate the config file veth_mac_addrs.conf that contains the MAC addrs as this can be used by the script veth_setup.sh.